### PR TITLE
Fixed URL in plugin.json for updates

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,5 +5,5 @@
 	"name": "Framewise Strain",
 	"author": "Christopher Haggerty",
 	"email": "chris.m.haggerty@gmail.com",
-	"url": "https:\/\/github.com\/chaggerty\/framewise_denseanalysis"
+	"url": "https:\/\/github.com\/fornwaltlab\/framewise_strain_plugin"
 }


### PR DESCRIPTION
This fixes the URL in the plugin manifest, so that updates will work correctly.

Any existing plugin will need to be uninstalled and re-installed for updates to work properly